### PR TITLE
Ruby methods and testing - Implement student_email_list on Course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -4,4 +4,20 @@ class Course < ApplicationRecord
   has_many :enrollments
 
   delegate :title, to: :coding_class
+
+  def student_name_list
+    names_list = []
+    self.enrollments.each do |enrollment|
+      names_list << "#{enrollment.student.first_name} #{enrollment.student.last_name}"
+    end 
+    names_list 
+  end 
+
+  def student_email_list 
+    email_list = []
+    self.enrollments.each do |enrollment|
+      email_list << "#{enrollment.student.email}"
+    end 
+    email_list 
+  end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -3,3 +3,4 @@ class Submission < ApplicationRecord
   belongs_to :student
   belongs_to :mentor
 end
+

--- a/db/migrate/20250324235506_create_submissions.rb
+++ b/db/migrate/20250324235506_create_submissions.rb
@@ -2,7 +2,7 @@ class CreateSubmissions < ActiveRecord::Migration[8.0]
   def change
     create_table :submissions do |t|
       t.references :student, null: false, foreign_key: true 
-      t.references :lensson, null: false, foreign_key: true 
+      t.references :lesson, null: false, foreign_key: true 
       t.references :enrollment, null: false, foreign_key: true 
       t.references :mentor, null: false, foreign_key: true
       t.string :pull_request_url, null: false 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,7 +42,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_24_235506) do
     t.integer "course_id", null: false
     t.integer "lesson_number"
     t.string "title"
-    t.string "url"
     t.date "assignment_due_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -77,7 +76,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_24_235506) do
 
   create_table "submissions", force: :cascade do |t|
     t.integer "student_id", null: false
-    t.integer "lensson_id", null: false
+    t.integer "lesson_id", null: false
     t.integer "enrollment_id", null: false
     t.integer "mentor_id", null: false
     t.string "pull_request_url", null: false
@@ -86,7 +85,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_24_235506) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["enrollment_id"], name: "index_submissions_on_enrollment_id"
-    t.index ["lensson_id"], name: "index_submissions_on_lensson_id"
+    t.index ["lesson_id"], name: "index_submissions_on_lesson_id"
     t.index ["mentor_id"], name: "index_submissions_on_mentor_id"
     t.index ["student_id"], name: "index_submissions_on_student_id"
   end
@@ -109,7 +108,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_24_235506) do
   add_foreign_key "mentor_enrollment_assignments", "enrollments"
   add_foreign_key "mentor_enrollment_assignments", "mentors"
   add_foreign_key "submissions", "enrollments"
-  add_foreign_key "submissions", "lenssons"
+  add_foreign_key "submissions", "lessons"
   add_foreign_key "submissions", "mentors"
   add_foreign_key "submissions", "students"
 end

--- a/lesson-05-assignment-screenshot.txt
+++ b/lesson-05-assignment-screenshot.txt
@@ -1,0 +1,9 @@
+All test passed no failures - copy the command and message from the terminal as reference:
+
+(base) sisiwang@Sisis-MacBook-Pro rails-dream-of-code-app % bundle exec rspec spec/models/course_spec.rb
+...WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. `NoMethodError`, `NameError` and `ArgumentError`), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/sisiwang/Code/ruby/rails-dream-of-code-app/spec/models/course_spec.rb:51:in `block (3 levels) in <top (required)>'.
+...WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. `NoMethodError`, `NameError` and `ArgumentError`), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/sisiwang/Code/ruby/rails-dream-of-code-app/spec/models/course_spec.rb:106:in `block (3 levels) in <top (required)>'.
+...
+
+Finished in 0.0542 seconds (files took 1.14 seconds to load)
+9 examples, 0 failures

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Course, type: :model do
     end
   end
 
-  describe '.student_name_list', skip: true do
+  describe '.student_name_list' do
     # First, we'll write a test that expects the method to exist
     # for an instance of a course
     it 'exists for a course' do
@@ -101,7 +101,7 @@ RSpec.describe Course, type: :model do
     end
   end
 
-  describe '.student_email_list', skip: true do
+  describe '.student_email_list' do
     it 'exists for a course' do
       expect { course.student_email_list }.not_to raise_error(NoMethodError)
     end


### PR DESCRIPTION
Implement student_email_list on Course, tested and all have been passed.

Here is the message from the terminal:
(base) sisiwang@Sisis-MacBook-Pro rails-dream-of-code-app % bundle exec rspec spec/models/course_spec.rb
...WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. `NoMethodError`, `NameError` and `ArgumentError`), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/sisiwang/Code/ruby/rails-dream-of-code-app/spec/models/course_spec.rb:51:in `block (3 levels) in <top (required)>'.
...WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. `NoMethodError`, `NameError` and `ArgumentError`), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/sisiwang/Code/ruby/rails-dream-of-code-app/spec/models/course_spec.rb:106:in `block (3 levels) in <top (required)>'.
...

Finished in 0.0542 seconds (files took 1.14 seconds to load)
9 examples, 0 failures